### PR TITLE
SEO: Site config & custom pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,7 +12,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: 'Welcome to the Datacoves Documentation',
+  title: 'Datacoves',
   tagline: 'Our Mission is to be the best dbt platform for enterprises by offering a simple solution with robust orchestration that reduces time to market while handling the complexities of a large enterprise.',
   favicon: 'img/favicon.ico',
 

--- a/src/pages/contact-us.md
+++ b/src/pages/contact-us.md
@@ -1,5 +1,5 @@
 ---
-title: Contact Datacoves Support via Slack or Email
+title: Contact Datacoves Support
 description: "Reach the Datacoves support team via Slack, email, or our Service Desk portal. Enterprise customers get priority response through a dedicated Slack channel."
 ---
 

--- a/src/pages/contact-us.md
+++ b/src/pages/contact-us.md
@@ -1,5 +1,6 @@
 ---
-title: Contact Us
+title: Contact Datacoves Support via Slack or Email
+description: "Reach the Datacoves support team via Slack, email, or our Service Desk portal. Enterprise customers get priority response through a dedicated Slack channel."
 ---
 
 # Contact Us

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -33,7 +33,7 @@ export default function Home() {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title="Datacoves Docs: dbt, Airflow & Data Engineering"
+      title="Docs: dbt, Airflow & Data Engineering"
       description="Official documentation for Datacoves — the enterprise dbt platform with Airflow orchestration, VS Code, and Superset. Get started in minutes.">
       <HomepageHeader />
       <main>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,7 +14,7 @@ function HomepageHeader() {
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <Heading as="h1" className="hero__title">
-          {siteConfig.title}
+          Welcome to the Datacoves Documentation
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
         <div className={styles.buttons}>
@@ -33,8 +33,8 @@ export default function Home() {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      title="Datacoves Docs: dbt, Airflow & Data Engineering"
+      description="Official documentation for Datacoves — the enterprise dbt platform with Airflow orchestration, VS Code, and Superset. Get started in minutes.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />

--- a/src/pages/sla.md
+++ b/src/pages/sla.md
@@ -1,6 +1,6 @@
 ---
 title: Datacoves Service Level Agreement (SLA)
-description: "Datacoves SLA: 99.9% uptime commitment, support severity levels with defined response times, credit schedule for outages, and availability exceptions."
+description: "Datacoves SLA: 99.9% uptime commitment, support severity levels with defined response times, and availability exceptions."
 ---
 
 # Service Level Agreement (SLA)

--- a/src/pages/sla.md
+++ b/src/pages/sla.md
@@ -1,3 +1,8 @@
+---
+title: Datacoves Service Level Agreement (SLA)
+description: "Datacoves SLA: 99.9% uptime commitment, support severity levels with defined response times, credit schedule for outages, and availability exceptions."
+---
+
 # Service Level Agreement (SLA)
 
 This document outlines Datacoves' responsibility with regards to outages and other issues with the Datacoves platform.


### PR DESCRIPTION
Shorten site title in docusaurus.config.js, fix homepage meta description, and add SEO front-matter to contact-us and sla pages.