### PR TITLE
SEO: Reference & Tutorials sections

### DIFF
--- a/docs/reference/admin-menu/README.md
+++ b/docs/reference/admin-menu/README.md
@@ -1,5 +1,7 @@
 ---
-title: Administration Menu
+title: Datacoves Administration Menu Reference
+sidebar_label: Administration Menu
+description: "Reference guide to the Datacoves Administration Menu, covering projects, environments, users, groups, service connections, secrets, and billing settings."
 sidebar_position: 1
 ---
 # Admininstration Menu

--- a/docs/reference/admin-menu/connection_templates.md
+++ b/docs/reference/admin-menu/connection_templates.md
@@ -1,5 +1,7 @@
 ---
-title: Connection Templates
+title: "Connection Templates Reference: Datacoves Admin"
+sidebar_label: Connection Templates
+description: "Reference documentation for Datacoves connection templates: configure reusable data warehouse credential templates for use across projects and environments."
 sidebar_position: 20
 ---
 # Connection Templates Admin

--- a/docs/reference/admin-menu/environments.md
+++ b/docs/reference/admin-menu/environments.md
@@ -1,5 +1,7 @@
 ---
-title: Environments
+title: "Environments Reference: Datacoves Admin Panel"
+sidebar_label: Environments
+description: "Reference for the Datacoves Environments admin screen: configure VS Code, Airflow, Superset, integrations, and service connections per environment."
 sidebar_position: 30
 ---
 # Environments Admin

--- a/docs/reference/admin-menu/external_links.md
+++ b/docs/reference/admin-menu/external_links.md
@@ -1,5 +1,7 @@
 ---
-title: External Links
+title: "External Links Reference: Datacoves Admin Panel"
+sidebar_label: External Links
+description: "Configure external links in the Datacoves admin panel to add custom URLs to the navigation menu for quick access to tools, dashboards, or documentation."
 sidebar_position: 40
 ---
 # External Links

--- a/docs/reference/admin-menu/groups.md
+++ b/docs/reference/admin-menu/groups.md
@@ -1,5 +1,7 @@
 ---
-title: Groups
+title: "Groups Reference: Datacoves Admin Panel"
+sidebar_label: Groups
+description: "Reference for the Datacoves Groups admin screen: create and configure role-based user groups with access to specific projects and environments."
 sidebar_position: 50
 ---
 # Groups Admin

--- a/docs/reference/admin-menu/integrations.md
+++ b/docs/reference/admin-menu/integrations.md
@@ -1,5 +1,7 @@
 ---
-title: Integrations
+title: "Integrations Reference: Datacoves Admin Panel"
+sidebar_label: Integrations
+description: "Reference for the Datacoves Integrations admin screen: configure notification services like Slack and Microsoft Teams for Airflow pipeline alerts."
 sidebar_position: 60
 ---
 # Integrations Admin

--- a/docs/reference/admin-menu/invitations.md
+++ b/docs/reference/admin-menu/invitations.md
@@ -1,5 +1,7 @@
 ---
-title: Invitations
+title: "Invitations Reference: Datacoves Admin Panel"
+sidebar_label: Invitations
+description: "Reference for the Datacoves Invitations admin screen: view pending invitations, resend invitation emails, and manage user access requests."
 sidebar_position: 60
 ---
 # Invitations Admin

--- a/docs/reference/admin-menu/projects.md
+++ b/docs/reference/admin-menu/projects.md
@@ -1,5 +1,7 @@
 ---
-title: Projects
+title: "Projects Reference: Datacoves Admin Panel"
+sidebar_label: Projects
+description: "Reference for the Datacoves Projects admin screen: manage git repository settings, CI/CD integration, and secrets backend per project."
 sidebar_position: 70
 ---
 # Projects Admin

--- a/docs/reference/admin-menu/secrets.md
+++ b/docs/reference/admin-menu/secrets.md
@@ -1,5 +1,7 @@
 ---
-title: Secrets
+title: "Secrets Reference: Datacoves Admin Panel"
+sidebar_label: Secrets
+description: "Reference for the Datacoves Secrets admin screen: create and manage encrypted secrets for injecting credentials into developer environments."
 sidebar_position: 80
 ---
 # Secrets Admin

--- a/docs/reference/admin-menu/service_connections.md
+++ b/docs/reference/admin-menu/service_connections.md
@@ -1,5 +1,7 @@
 ---
-title: Service Connections
+title: "Service Connections Reference: Datacoves Admin"
+sidebar_label: Service Connections
+description: "Reference for the Datacoves Service Connections admin screen: configure warehouse credential delivery to Airflow and VS Code environments."
 sidebar_position: 90
 ---
 # Service Connections Admin

--- a/docs/reference/admin-menu/settings_billing.md
+++ b/docs/reference/admin-menu/settings_billing.md
@@ -1,5 +1,7 @@
 ---
-title: Account Settings & Billing
+title: "Account Settings & Billing Reference: Datacoves"
+sidebar_label: Account Settings & Billing
+description: "Reference for Datacoves account settings and billing: view subscription details, manage API keys, access the Billing API URL, and monitor usage."
 sidebar_position: 10
 ---
 # Account Settings & Billing

--- a/docs/reference/admin-menu/users.md
+++ b/docs/reference/admin-menu/users.md
@@ -1,5 +1,7 @@
 ---
-title: Users
+title: "Users Reference: Datacoves Admin Panel"
+sidebar_label: Users
+description: "Reference for the Datacoves Users admin screen: view all platform users, modify roles and permissions, deactivate or delete user accounts."
 sidebar_position: 100
 ---
 # Users Admin

--- a/docs/reference/airflow/airflow-best-practices.md
+++ b/docs/reference/airflow/airflow-best-practices.md
@@ -1,5 +1,7 @@
 ---
-title: Airflow Best Practices
+title: Airflow DAG Best Practices for Datacoves Users
+sidebar_label: Best Practices
+description: "Recommended Airflow best practices for Datacoves: set static start dates, use catchup=False, avoid dynamic scheduled dates, and follow official Airflow docs."
 sidebar_position: 121
 ---
 # Airflow Best Practices

--- a/docs/reference/airflow/airflow-billing.md
+++ b/docs/reference/airflow/airflow-billing.md
@@ -1,5 +1,7 @@
 ---
-title: Airflow Billing
+title: Airflow Billing and Worker Usage in Datacoves
+sidebar_label: Billing
+description: "Understand how Datacoves bills Airflow usage based on Kubernetes worker pod running time, what is and isn't billed, and how to query task instance tables."
 ---
 
 # How Datacoves Billing Works

--- a/docs/reference/airflow/airflow-config-defaults.md
+++ b/docs/reference/airflow/airflow-config-defaults.md
@@ -1,5 +1,7 @@
 ---
-title: Airflow Config Defaults
+title: Airflow Default Configuration in Datacoves
+sidebar_label: Config Defaults
+description: "Reference for Datacoves Airflow default configuration: executor, parallelism, scheduler, Kubernetes worker timeout, and database retry settings."
 sidebar_position: 122
 ---
 # Airflow Config Defaults

--- a/docs/reference/airflow/airflow-variables.md
+++ b/docs/reference/airflow/airflow-variables.md
@@ -1,5 +1,7 @@
 ---
-title: Airflow Variables
+title: Datacoves Airflow Environment Variables
+sidebar_label: Variables
+description: "Reference for Datacoves-injected Airflow variables: DAG paths, dbt settings, environment slugs, version info, and notification configuration."
 sidebar_position: 123
 ---
 Datacoves injects several environment variables into Apache Airflow to streamline workflow configurations. Below is a list of important variables you may encounter:

--- a/docs/reference/airflow/dag-generators.md
+++ b/docs/reference/airflow/dag-generators.md
@@ -1,5 +1,7 @@
 ---
-title: DAG Generators
+title: "DAG Generators Reference: Airbyte and Fivetran"
+sidebar_label: DAG Generators
+description: "Reference for dbt-coves DAG generators in Datacoves: AirbyteGenerator, AirbyteDbtGenerator, FivetranGenerator, and FivetranDbtGenerator with all params."
 sidebar_position: 124
 ---
 # DAG Generators

--- a/docs/reference/airflow/datacoves-commands.md
+++ b/docs/reference/airflow/datacoves-commands.md
@@ -1,5 +1,7 @@
 ---
-title: Datacoves CLI Commands
+title: "Datacoves CLI Commands Reference: datacoves my"
+sidebar_label: CLI Commands
+description: "Reference for Datacoves CLI commands: datacoves my import, my pytest, and my api-key for managing My Airflow instances from the VS Code terminal."
 sidebar_position: 126
 ---
 # Datacoves CLI Commands

--- a/docs/reference/airflow/datacoves-decorators.md
+++ b/docs/reference/airflow/datacoves-decorators.md
@@ -1,5 +1,7 @@
 ---
-title: Datacoves Airflow Decorators
+title: Datacoves Airflow Decorators Reference
+sidebar_label: Decorators
+description: "Reference for Datacoves Airflow decorators: @task.datacoves_bash and @task.datacoves_dbt — parameters, usage examples, and service connection integration."
 sidebar_position: 125
 ---
 # Datacoves Airflow Decorators

--- a/docs/reference/airflow/datacoves-operator.md
+++ b/docs/reference/airflow/datacoves-operator.md
@@ -1,5 +1,7 @@
 ---
-title: Datacoves Operators
+title: Datacoves Airflow Operators and Generators
+sidebar_label: Operators
+description: "Reference for Datacoves Airflow operators: DatacovesBashOperator and DatacovesDbtOperator, their parameters, behavior, and usage examples in DAG files."
 sidebar_position: 128
 ---
 # Datacoves Operators & Generators

--- a/docs/reference/airflow/environment-service-connection-vars.md
+++ b/docs/reference/airflow/environment-service-connection-vars.md
@@ -1,5 +1,7 @@
 ---
-title: Datacoves Environment Service Connection Variables
+title: Datacoves Service Connection Variables Reference
+sidebar_label: Service Connection Vars
+description: "Environment variables injected by Datacoves service connections for Snowflake, Redshift, BigQuery, and Databricks warehouse authentication in Airflow."
 sidebar_position: 127
 ---
 # Warehouse Environment Variables

--- a/docs/reference/datacoves/rollback-strategy.md
+++ b/docs/reference/datacoves/rollback-strategy.md
@@ -1,6 +1,7 @@
 ---
-title: Rollback Strategy
+title: Datacoves Platform Rollback Strategy Reference
 sidebar_label: Rollback Strategy
+description: "How Datacoves handles rollbacks across infrastructure, platform services, and customer image layers, including hotfix processes and rollback limitations."
 sidebar_position: 132
 ---
 

--- a/docs/reference/datacoves/versioning.md
+++ b/docs/reference/datacoves/versioning.md
@@ -1,5 +1,7 @@
 ---
-title: Versioning
+title: "Datacoves Versioning: Semantic Version Reference"
+sidebar_label: Versioning
+description: "How Datacoves uses semantic versioning (MAJOR.MINOR.PATCH) for Docker images and platform releases, including version bump criteria and image tag formats."
 sidebar_position: 130
 ---
 # Datacoves versioning

--- a/docs/reference/datacoves/vpc-deployment.md
+++ b/docs/reference/datacoves/vpc-deployment.md
@@ -1,5 +1,7 @@
 ---
-title: VPC Deployment
+title: Datacoves VPC Deployment Architecture Reference
+sidebar_label: VPC Deployment
+description: "Infrastructure requirements for deploying Datacoves on a private VPC: database, blob storage, Kubernetes, git server, CI/CD, DNS, and HTTPS certificates."
 sidebar_position: 131
 ---
 # VPC Deployment

--- a/docs/reference/security/README.md
+++ b/docs/reference/security/README.md
@@ -1,5 +1,7 @@
 ---
-title: Security
+title: Datacoves Security Features and Compliance Info
+sidebar_label: Security
+description: "Datacoves security overview: SSO via Google or Microsoft, role-based access control, HTTPS enforcement, AES-128 encryption at rest, and cloud protocols."
 sidebar_position: 134
 ---
 # Datacoves Security

--- a/docs/reference/vscode/README.md
+++ b/docs/reference/vscode/README.md
@@ -1,5 +1,7 @@
 ---
-title: VS Code
+title: VS Code Reference for Datacoves Environments
+sidebar_label: VS Code
+description: "Reference documentation for VS Code in the Datacoves Transform tab, including environment variables, settings overrides, and extension configurations."
 sidebar_position: 150
 ---
 # Datacoves reference - vscode

--- a/docs/reference/vscode/datacoves-env-vars.md
+++ b/docs/reference/vscode/datacoves-env-vars.md
@@ -1,5 +1,7 @@
 ---
-title: Datacoves Environment Variables
+title: Datacoves VS Code Environment Variables
+sidebar_label: Environment Variables
+description: "Reference for all Datacoves-injected environment variables in VS Code: workspace paths, dbt settings, version info, and warehouse connection details."
 sidebar_position: 137
 ---
 # Datacoves Environment Variables

--- a/docs/tutorials/educational-data-resources.mdx
+++ b/docs/tutorials/educational-data-resources.mdx
@@ -1,5 +1,7 @@
 ---
 title: Educational Data Resources
+sidebar_label: Educational Data Resources
+description: "A curated collection of free datasets and educational resources for learning and practicing data engineering and analytics skills."
 ---
 
 <meta http-equiv="refresh" content="0; url=https://datacoves.com/data-resources#Educational" />

--- a/docs/tutorials/learning-resources.mdx
+++ b/docs/tutorials/learning-resources.mdx
@@ -1,5 +1,7 @@
 ---
-title: Learning Resources
+title: Datacoves Learning Resources for Data Engineers
+sidebar_label: Learning Resources
+description: "Curated guides, videos, and documentation to help you get started with dbt, Airflow, and data engineering in the Datacoves platform."
 ---
 
 <meta http-equiv="refresh" content="0; url=https://datacoves.com/learning-resources?_gl=1*18cmhau*_ga*MjYwMzYwODE1LjE3NTIyNTAwNDk.*_ga_WFBP8GG4YV*czE3NTYyNDYzMzAkbzUwJGcxJHQxNzU2MjQ2NDg4JGo2MCRsMCRoMA.." />


### PR DESCRIPTION
Add descriptive titles, sidebar_label, and meta descriptions to all Reference pages (Admin Menu, Airflow, Datacoves, Security, VS Code) and Tutorials.